### PR TITLE
Updated setColorTheme to allow use of default colors

### DIFF
--- a/src/graphics/GraphicalTimer.java
+++ b/src/graphics/GraphicalTimer.java
@@ -44,6 +44,6 @@ public interface GraphicalTimer {
 	 *                        setColorTheme("#FFFFFF","#000000","#7F7F7F")
 	 * @return True if a change is made, false otherwise.
 	 */
-	public boolean setColorTheme(String... hexColorStrings);
+	public boolean setColorTheme(boolean useDefaultColors, String... hexColorStrings);
 
 }


### PR DESCRIPTION
Updated the declaration of setColorTheme to allow for the use of default colors defined by the GraphicalTimer implementation's author.